### PR TITLE
Allow to deploy to multiple regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ After reviewing the source code to make sure there isn't anything in there you d
 
 ```sh
   npm install -g aws-architect-cf-macros
-  aws-architect-cf-macros deploy TMP_DEPLOYMENT_BUCKET --profile PROFILE_NAME
-
+  aws-architect-cf-macros deploy TMP_DEPLOYMENT_BUCKET --profile PROFILE_NAME --region AWS_REGION
 ```
 
+Parameters `profile` and `region` are optional. If not specified, take the default depending on your AWS settings.

--- a/bin/aws-architect-cf-macros.js
+++ b/bin/aws-architect-cf-macros.js
@@ -9,8 +9,9 @@ const packageMetadata = require(packageMetadataFile);
 commander
   .command('deploy <bucket>')
   .description('Deploy the AWS Architect macro to your default region from an s3 bucket.')
-  .usage('deploy <bucket> --profile PROFILE_NAME')
+  .usage('deploy <bucket> --profile PROFILE_NAME --region REGION')
   .option('-p, --profile <profile>', 'set the AWS profile to use')
+  .option('-r, --region <region>', 'uses the AWS region')
   .action(async (bucket, options) => {
     if (options && options.profile) {
       process.env.AWS_SDK_LOAD_CONFIG = true;
@@ -22,6 +23,9 @@ commander
       sourceDirectory: path.join(__dirname, '..', 'lib'),
       description: 'AWS Architect Macro'
     };
+    if (options && options.region) {
+      apiOptions.regions = [options.region];
+    }
     let awsArchitect = new AwsArchitect(packageMetadata, apiOptions);
     let stackTemplate = require('./cloudFormationMacroTemplate.json');
 

--- a/bin/cloudFormationMacroTemplate.json
+++ b/bin/cloudFormationMacroTemplate.json
@@ -33,7 +33,8 @@
     "LambdaRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
-        "RoleName": "AwsArchitectMacroFunctionLambdaRole",
+        "RoleName": { "Fn::Sub": "AwsArchitectMacroFunctionLambdaRole-${AWS::Region}" },
+        "Description": "AWS Architect Macros: Role to execute Lambda function",
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [


### PR DESCRIPTION
* IAM role must have a unique name, otherwise the deployment in the 2nd region fails. (Also added a description to the role.)
* Allow to specify the region as command line parameter to avoid chaning the default value.